### PR TITLE
Add Recaptcha to Contact Form

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@ Live site can be found at [https://support.mycrypto.com](https://support.mycrypt
 ### Quick Start Guide
 To build this project locally, you need to have Node.js installed. Clone the project with Git and run:
 
-
 `$ cd support.mycrypto.com`
 
 `$ npm install`
 
-`$ gulp`
+`$ npm run dev`
 
 This will run Gulp to build the project and watch for changes. You can open `knowledge-base/dist/index.html` to view your local copy.

--- a/src/partials/form-main.hbs
+++ b/src/partials/form-main.hbs
@@ -1,3 +1,11 @@
+<script type="text/javascript">
+  var onloadCallback = function() {
+    grecaptcha.render('html_element', {
+      sitekey: '6LcOl00UAAAAACVjGdVFkw918ohOhPIL0PHDtdGM'
+    });
+  };
+</script>
+
 <main class="container-md">
 
   <h2>
@@ -565,7 +573,18 @@
     <!-- Field: Body (Will be filled in via JS - msg + subject + additional fields) -->
     <textarea class="form-control" name="body" id="textarea_body" rows="1" style="display:none;"></textarea>
 
-    <div id="html_element"></div>
+    <!-- Recaptcha will load here -->
+    <section class="form-group row">
+      <label for="attachment" class="col-3 col-form-label">
+        Captcha
+        <small id="detailsHelper" class="form-text text-muted">
+          Sorry, we just need to make sure you’re human.
+        </small>
+      </label>
+      <div class="col-9">
+        <div id="html_element"></div>
+      </div>
+    </section>
+    <script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit" async defer></script>
 
   </main>
-


### PR DESCRIPTION
Adds a recaptcha box to the contact us form at the bottom of articles, due to spam the support team has been getting.

![screen shot 2018-03-19 at 3 26 22 pm](https://user-images.githubusercontent.com/649992/37617825-976b98d8-2b8a-11e8-964a-c56d1e70042f.png)

Must be launched at the same time that we enable this on Front! Please hit me up with instructions when we're ready to launch.