### PR TITLE
Update bits about Ledger browser support

### DIFF
--- a/src/content/accessing-your-wallet/how-to-use-your-ledger-with-mycrypto.md
+++ b/src/content/accessing-your-wallet/how-to-use-your-ledger-with-mycrypto.md
@@ -4,7 +4,7 @@
 "category"    : "Accessing your Wallet",
 "description"    : "Accessing your Wallet",
 "date_published" : "2018-04-18T08:00:00+08:00",
-"date_modified"  : "2018-04-18T09:07:00+08:00"
+"date_modified"  : "2018-08-14T08:00:00+08:00"
 }
 
 ---%
@@ -40,6 +40,8 @@ Now your Ledger Nano S is all set-up and ready to be used!
 ###  Enabling your Ledger Nano S to work with MyCrypto
 
 In order to make your Nano S work with MyCrypto, we will need to enable browser support. We are also going to enable contract data while we're at it, so we can have the ability to create token transfers as well.
+
+**In newer versions of the Ethereum app on the Ledger, the "Browser Support" option is no longer available. It's already enabled. However, "Contract Data" is not enabled by default.**
 
 <img src="../images/ledger-migration/ethereum-app.jpg" style="width: 100%; height: auto; max-width: 400px;">
 

--- a/src/content/hardware-wallets/error-code-5.md
+++ b/src/content/hardware-wallets/error-code-5.md
@@ -4,7 +4,7 @@
 "category" : "Hardware Wallets",
 "description" : "Hardware Wallets",
 "date_published" : "2018-01-01T08:00:00+08:00",
-"date_modified" : "2018-07-17T08:00:00+08:00"
+"date_modified" : "2018-08-14T08:00:00+08:00"
 }
 
 ---%
@@ -16,6 +16,8 @@ Close all other Ethereum applications, Ledger applications, and MyCrypto tabs. E
 
 
 ### Turn On Browser Support
+
+**Please be aware that the newer versions of the Ethereum app on the Ledger device do not have the Browser Support option, it is already enabled. If you do not have the newest version of the Ethereum app, follow the following steps:**
 
 1. If you're trying to unlock your account on MyCrypto.com using your Ledger, make sure it's connected and unlock the device using your pin!
 

--- a/src/content/hardware-wallets/ledger-hardware-wallet-unable-to-connect-on-mycrypto.md
+++ b/src/content/hardware-wallets/ledger-hardware-wallet-unable-to-connect-on-mycrypto.md
@@ -4,7 +4,7 @@
 "category"    : "Hardware Wallets",
 "description" : "Hardware Wallets",
 "date_published" : "2017-07-15T08:00:00+08:00",
-"date_modified"  : "2018-07-19T08:00:00+08:00"
+"date_modified"  : "2018-08-14T08:00:00+08:00"
 }
 
 ---%
@@ -16,7 +16,7 @@ Sample Error Message: *"Your Ledger is currently in use with another application
 *   Restart your computer (Do not be lazy. Restart it FIRST).
 *   Use Google Chrome or the [MyCrypto Desktop App](https://download.mycrypto.com/).
 *   Make sure you don't have any other apps that connect to your Ledger open (e.g. the Ledger Bitcoin Chrome app, Mist, etc.)
-*   Make sure you have browser support turned ON. (This option is on the Ledger Nano S itself in Settings, this setting ensures that the Ledger is able to connect to the web browser)
+*   Make sure you have browser support turned ON. (This option is on the Ledger Nano S itself in Settings, this setting ensures that the Ledger is able to connect to the web browser. This setting is not available in newer versions of the Ledger app, it is already enabled.)
 *   Make sure you have contract data turned ON for MyCrypto.com or OFF for the desktop app. (This option is also on the Ledger Nano S itself in Settings)
 *   That you are confirming any transactions via your Ledger.
 *   Try a different USB cable

--- a/src/content/hardware-wallets/ledger-hardware-wallet-using-with-android.md
+++ b/src/content/hardware-wallets/ledger-hardware-wallet-using-with-android.md
@@ -4,7 +4,7 @@
 "category"    : "Hardware Wallets",
 "description" : "Hardware Wallets",
 "date_published" : "2015-12-29T08:00:00+08:00",
-"date_modified"  : "2017-12-29T08:00:00+08:00"
+"date_modified"  : "2018-08-14T08:00:00+08:00"
 }
 
 ---%
@@ -18,8 +18,10 @@ If you are not sure if your device supports USB-OTG, the easiest way to check it
 ### Setting up your device
 Before you connect your Ledger Wallet to your device, you first have to install an application made by Ledger. You can find the application [here](https://github.com/LedgerHQ/android-u2f-bridge/releases). Simply open the URL on your device and click on the file `android-u2f-bridge-x.x.apk`. Once you downloaded the file, open it on your device and you should be asked to install it. Once installed, tap `Done`, as it is not possible to open the app.
 
-Now, connect your Ledger Wallet and open the Ethereum. Make sure both `Contract Data` and `Browser Support` are **ON**. Open your browser and go to MyCrypto. On the Send Ether & Tokens page, select the Ledger Wallet option and tap on `Connect to Ledger Wallet`.
+Now, connect your Ledger Wallet and open the Ethereum. Make sure both `Contract Data` and `Browser Support`* are **ON**. Open your browser and go to MyCrypto. On the View & Send page, select the Ledger Wallet option and tap on `Connect to Ledger Wallet`.
 
 ![](../images/hardware-wallets/ledger-hardware-wallet-using-with-android-01.png)
 
 You should see a popup, asking if you want to allow the Ledger application you just installed to access the Ledger Wallet. Tap on `OK` and you should be able to see your addresses on MyCrypto.
+
+\* No longer available in newer versions of the Ethereum app on Ledger, enabled by default.

--- a/src/content/migration/moving-from-private-key-to-ledger-hardware-wallet.md
+++ b/src/content/migration/moving-from-private-key-to-ledger-hardware-wallet.md
@@ -4,7 +4,7 @@
 "category"    : "Migrating to/from MyCrypto",
 "description" : "Migrating to/from MyCrypto",
 "date_published" : "2017-10-08T08:00:00+08:00",
-"date_modified"  : "2018-05-11T08:00:00+08:00"
+"date_modified"  : "2018-08-14T08:00:00+08:00"
 }
 
 ---%
@@ -38,6 +38,8 @@ Now your Ledger Nano S is all set-up and ready to be used!
 ###  Enabling your Ledger Nano S to work with MyCrypto
 
 In order to make your Nano S work with MyCrypto, we will need to enable browser support. We are also going to enable contract data while we're at it, so we can have the ability to create token transfers as well.
+
+**In newer versions of the Ethereum app on the Ledger, the "Browser Support" option is no longer available. It's already enabled. However, "Contract Data" is not enabled by default.**
 
 <img src="../images/ledger-migration/ethereum-app.jpg" style="width: 100%; height: auto; max-width: 400px;">
 


### PR DESCRIPTION
Newest versions of the Ethereum application on Ledger no longer have the "Browser Support" option.