### PR TITLE
Update documentation for local node connection

### DIFF
--- a/src/content/networks/cant-connect-to-custom-node-on-mycrypto.md
+++ b/src/content/networks/cant-connect-to-custom-node-on-mycrypto.md
@@ -15,7 +15,7 @@
 *   Verify that if you are connecting to an http:// node you are running MyCrypto locally (NOT over https://).
 *   Verify you are running with:
       *  geth: `geth --rpc --rpccorsdomain "null" --keystore "dont_put_secret_files_here_ever"`
-      *  parity: `parity --jsonrpc-cors "null" --keystore "dont_put_secret_files_here_ever"`
+      *  parity: `parity --jsonrpc-cors "null" --keys-path "dont_put_secret_files_here_ever"`
 *   Verify your node is actually up and running.
 *   Try removing the node and adding it again.
 *   Try changing the node in the top-right corner to ETH (Etherscan.io) or ETH (Infurio.io).

--- a/src/content/networks/cant-connect-to-custom-node-on-mycrypto.md
+++ b/src/content/networks/cant-connect-to-custom-node-on-mycrypto.md
@@ -13,9 +13,9 @@
 *   Verify the URL you entered is correct.
 *   Verify the port you entered is correct.
 *   Verify that if you are connecting to an http:// node you are running MyCrypto locally (NOT over https://).
-*   Verify you are is running with:
-      *  `geth --rpc --rpccorsdomain "null" --keystore "dont_put_secret_files_here_ever"`
-      *  parity is running with `parity --rpccorsdomain "*" --keys-path "dont_put_secret_files_here_ever"`
+*   Verify you are running with:
+      *  geth: `geth --rpc --rpccorsdomain "null" --keystore "dont_put_secret_files_here_ever"`
+      *  parity: `parity --jsonrpc-cors "null" --keystore "dont_put_secret_files_here_ever"`
 *   Verify your node is actually up and running.
 *   Try removing the node and adding it again.
 *   Try changing the node in the top-right corner to ETH (Etherscan.io) or ETH (Infurio.io).

--- a/src/content/networks/run-your-own-node-with-mycrypto.md
+++ b/src/content/networks/run-your-own-node-with-mycrypto.md
@@ -21,15 +21,13 @@ You will be using MyCrypto to sign and then broadcast the TXs via your node. You
 
 ### Specifics to Connect To Your Local Node
 
-##### [First, download and run MyCrypto locally.](https://support.mycrypto.com/offline/running-mycrypto-locally.html)
-
-* You must run MyCrypto locally. This is due to the fact that our SSL website won't connect to your non-SSL local node.
+##### [First, download and run MyCrypto Desktop App.](https://download.mycrypto.com/)
 
 #####  Run geth or parity with correct flags
 
   *   Geth: `geth --syncmode=light  --rpc --rpccorsdomain "null" --keystore "dont_put_secret_files_here_ever"`
 
-  *   Parity: `parity --rpccorsdomain "null" --keys-path "dont_put_secret_files_here_ever"`
+  *   Parity: `parity --jsonrpc-cors "null" --keys-path "dont_put_secret_files_here_ever"`
 
 ##### Connect to your node
 
@@ -41,11 +39,11 @@ You will be using MyCrypto to sign and then broadcast the TXs via your node. You
 
 *   Enter a `Node Name` for your node
 
-*   URL: `http://127.0.0.1`
+*   URL: `http://127.0.0.1:8545`
 
 *   Select the chain. This is for some frontend features, like default tokens and ENS addresses and more. See above for more details.
 
-![](https://i.imgur.com/cHUIdBV.png)
+![](https://i.imgur.com/wx5vZbs.jpg)
 
 * Click "Save & Use Custom Node".
 
@@ -107,14 +105,10 @@ If you wish to run MyCrypto locally + hardware wallet, you will need to have a s
 
 - [One way to do this is detailed here](https://support.mycrypto.com/offline/using-ledger-wallet-offline.html)
 
-### Whoa, back up. How do I even run a node?
-
-[WIP]
-
 #### Parity
 
-* https://github.com/paritytech/parity/wiki/Getting-Synced
+* https://wiki.parity.io/FAQ
 
-* https://github.com/paritytech/parity/releases
+* https://github.com/paritytech/parity-ethereum/releases
 
 #### Geth


### PR DESCRIPTION
- Use `jsonrpc-cors` for parity (the previously mentioned flag is deprecated)
- Use 8545 as http port otherwise local connection doesn't work (see https://github.com/MyCryptoHQ/MyCrypto/issues/2113)

Question:
I believe that writing `--keys-path "dont_put_secret_files_here_ever"` is confusing for your users. I'd be happy to help getting something a little clearer. Node users most probably always have some keys in their `/keys` directory and that's fine (it's encrypted) as long as they don't unlock their account (why would they do it?). Security best practices is something we cover in [parity's wiki](https://wiki.parity.io/FAQ#what-are-the-security-best-practices)