### PR TITLE
Update adding-custom-token-errors-fix.md

### DIFF
--- a/src/content/tokens/adding-custom-token-errors-fix.md
+++ b/src/content/tokens/adding-custom-token-errors-fix.md
@@ -18,7 +18,7 @@ A `Not a valid ERC-20 token` error can occur when an incorrect contract address 
 Be sure to use the correct contract address, not adding the correct contract address will show that you own 0 of the tokens you are trying to add. 
 
 #### "I added a token, I'm suppose to have 25.57 tokens but it shows 0.002557"
-This happens when you accidentally inputted the incorrect decimal value when entering custom token details. 
+This happens when you input an incorrect decimal value while entering custom token details. 
 
 To fix these errors please remove the token from your MyCrypto Interface and re-add the token. To remove a custom token, click the little `( - )` icon next to token you wish to re-add. This will remove it from the interface. It is not deleting or removing the tokens from your wallet, they are still safely in your wallet, we promise.
 


### PR DESCRIPTION
Absolutely atrocious: This happens when you accidentally inputted the incorrect decimal value when entering custom token details.

Alternatives I wrestled with:
1.) This happens when you accidentally input an incorrect decimal value while entering custom token details. (still technically correct, except you should avoid using 'when' twice in that same sentence).
2.) This happens when you have accidentally input an incorrect decimal value while entering custom token details.
3.) This happens after you have accidentally input an incorrect decimal value while entering custom token details.
4.) This happens once you have input an incorrect decimal value when entering custom token details.

Obviously, more combinations are possible.

Basically, 'inputted' sounds atrocious. The word is derived from 'put', which is both present and past tense. i.e., no 'ed' appended for past tense. There is a, 'putted', yet this pertains only to the game of golf and being Scottish in origin, is actually derived from the English verb put (just to add more confusion to the issue).

While the usage of 'inputted' as a past participle is sadly, not technically incorrect, Mirriam Webster adds, "When dealing with the verb, the issue of how to treat the past participle is a contentious one, with much blood being shed on both sides. Some people feel that the past participle of input should be input, not inputted, based on the reasoning that the word comes from put, and we don’t say “he putted the papers on the shelf.”, and further, "In other words, you'll probably offend someone no matter what you do. Welcome to the English language."

Here's a couple of links to muddy the waters a bit more:
https://english.stackexchange.com/questions/30684/inputted-or-input
https://www.merriam-webster.com/words-at-play/is-inputted-a-word 

Oh, and then there's that past participle for the sport of shot putting, which I didn't bother to mention, yet it too is derived from the verb, 'put'.

So long story short, although I didn't actually correct the grammar, I did make it prettier and presented the sentence in a way that won't raise the ire of people who twitch at weird sounding idiosyncratic aspects of the English language ;)

And finally, changing 'the', to 'an', is indeed a grammar fix, since there isn't just one possible incorrect value. 

I'm sorry to be such a biotch over such a trivial matter, but please, whatever you do, please use 'input', rather than 'inputted'.